### PR TITLE
Update Dockerfile — change -slim to -slim-bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG python_version=3.10
-FROM --platform=linux/amd64 python:${python_version}-slim AS base
+FROM --platform=linux/amd64 python:${python_version}-slim-bullseye AS base
 
 WORKDIR /usr/src/app
 
@@ -21,7 +21,7 @@ COPY tests/ tests/
 RUN poetry build
 
 
-FROM --platform=linux/amd64 python:${python_version}-slim AS askar-upgrade
+FROM --platform=linux/amd64 python:${python_version}-slim-bullseye AS askar-upgrade
 COPY --from=base /usr/src/app/dist/acapy_wallet_upgrade-*-py3-none-any.whl /tmp/.
 
 RUN pip install /tmp/acapy_wallet_upgrade-*-py3-none-any.whl && \


### PR DESCRIPTION
Not sure if this is useful, as the build worked with both `-slim` and `-slim-bullseye` — with the expected log differences, such as the reference to `bookworm` when using `-slim` and `bullseye` when set specifically.

I did not run the output of the build. I don’t have a setup to test with AFAIK.