### PR TITLE
Tenant Import Feature

### DIFF
--- a/askar_tools/README.md
+++ b/askar_tools/README.md
@@ -10,7 +10,6 @@
 poetry install
 ```
 
-
 ### Export Wallet:
 
  * Exports a wallet into a file with a readable json format. This can be useful for debugging or for sharing wallet information with others.
@@ -22,11 +21,13 @@ poetry install
     poetry run askar-tools \
     --strategy export \
     --uri postgres://<username>:<password>@<hostname>:<port>/<dbname> \
-    --base-wallet-name <base wallet name> \
-    --base-wallet-key <base wallet key>
+    --wallet-name <base wallet name> \
+    --wallet-key <base wallet key> \
+    --wallet-key-derivation-method <optional> \
+    --export-filename <optional>
     ```
 
-### Multitenant Wallet - Switch from single wallet to multi wallet:
+### Multi-tenant Wallet - Switch from single wallet to multi wallet:
 
 ##### Prerequisites:
     Backup sub-wallet. This operation will delete the sub-wallet when finished. If the wallet is broken for some reason you will not be able to recover it without a backup.
@@ -34,7 +35,7 @@ poetry install
  * Converts the profiles in the sub-wallet to individual wallets and databases.
  * After completion, the sub-wallet will be deleted and the deployment should no longer use the `--multitenancy-config '{"wallet_type": "single-wallet-askar"}'` configuration.
 
-- `export` (Output the contents of a wallet to a json file):
+- `mt-convert-to-mw` (Convert from single wallet to multi-wallet multi-tenant agent):
 
     ```
     poetry run askar-tools \ 
@@ -42,5 +43,31 @@ poetry install
     --uri postgres://<username>:<password>@<hostname>:<port>/<dbname> \ 
     --wallet-name <base wallet name> \
     --wallet-key <base wallet key> \ 
+    --wallet-key-derivation-method <optional> \
     --multitenant-sub-wallet-name <optional: custom sub wallet name>
+    ```
+
+### Import Wallet:
+
+ * Imports a wallet from a database location into a multi-tenant multi-wallet admin and database location.
+
+- `tenant-import` (Import a wallet into a multi-wallet multi-tenant agent):
+
+    ```
+    poetry run askar-tools \
+    --strategy tenant-import \
+    --uri postgres://<username>:<password>@<hostname>:<port>/<dbname> \
+    --wallet-name <base wallet name> \
+    --wallet-key <base wallet key> \
+    --wallet-key-derivation-method <optional> \
+    --tenant-uri postgres://<username>:<password>@<hostname>:<port>/<dbname> \
+    --tenant-wallet-name <tenant wallet name> \
+    --tenant-wallet-key <tenant wallet key> \
+    --tenant-wallet-key-derivation-method <optional> \
+    --tenant-wallet-type <optional: default is askar> \
+    --tenant-label <optional: default is None> \
+    --tenant-image-url <optional: default is None> \
+    --tenant-webhook-urls <optional: default is None> \
+    --tenant-extra-settings <optional: default is None> \
+    --tenant-dispatch-type <optional: default is None>
     ```

--- a/askar_tools/exporter.py
+++ b/askar_tools/exporter.py
@@ -5,6 +5,7 @@ from json import JSONDecodeError
 
 from aries_askar import Store
 
+from .key_methods import KEY_METHODS
 from .pg_connection import PgConnection
 from .sqlite_connection import SqliteConnection
 
@@ -17,6 +18,7 @@ class Exporter:
         conn: SqliteConnection | PgConnection,
         wallet_name: str,
         wallet_key: str,
+        wallet_key_derivation_method: str = "ARGON2I_MOD",
         export_filename: str = "wallet_export.json",
     ):
         """Initialize the Exporter object.
@@ -25,10 +27,13 @@ class Exporter:
             conn: The connection object.
             wallet_name: The name of the wallet.
             wallet_key: The key for the wallet.
+            wallet_key_derivation_method: The key derivation method for the wallet.
+            export_filename: The name of the export file.
         """
         self.conn = conn
         self.wallet_name = wallet_name
         self.wallet_key = wallet_key
+        self.wallet_key_derivation_method = wallet_key_derivation_method
         self.export_filename = export_filename
 
     async def _get_decoded_items_and_tags(self, store):
@@ -53,10 +58,14 @@ class Exporter:
 
     async def export(self):
         """Export the wallet data."""
-        print("Exporting wallet to wallet_export.json...")
+        print(f"Exporting wallet to {self.export_filename}...")
 
         tables = {"config": {}, "items": {}, "profiles": {}}
-        store = await Store.open(self.conn.uri, pass_key=self.wallet_key)
+        store = await Store.open(
+            self.conn.uri,
+            pass_key=self.wallet_key,
+            key_method=KEY_METHODS[self.wallet_key_derivation_method],
+        )
 
         tables["items"] = await self._get_decoded_items_and_tags(store)
 

--- a/askar_tools/exporter.py
+++ b/askar_tools/exporter.py
@@ -17,6 +17,7 @@ class Exporter:
         conn: SqliteConnection | PgConnection,
         wallet_name: str,
         wallet_key: str,
+        export_filename: str = "wallet_export.json",
     ):
         """Initialize the Exporter object.
 
@@ -28,6 +29,7 @@ class Exporter:
         self.conn = conn
         self.wallet_name = wallet_name
         self.wallet_key = wallet_key
+        self.export_filename = export_filename
 
     async def _get_decoded_items_and_tags(self, store):
         scan = store.scan()
@@ -62,7 +64,7 @@ class Exporter:
 
         tables["profiles"] = await self.conn.get_profiles()
 
-        with open("wallet_export.json", "w") as json_file:
+        with open(self.export_filename, "w") as json_file:
             json.dump(tables, json_file, indent=4)
 
         await store.close()

--- a/askar_tools/key_methods.py
+++ b/askar_tools/key_methods.py
@@ -1,0 +1,7 @@
+""".Key methods for Askar wallet."""
+
+KEY_METHODS = {
+    "RAW": "RAW",
+    "ARGON2I_INT": "kdf:argon2i:int",
+    "ARGON2I_MOD": "kdf:argon2i:mod",
+}

--- a/askar_tools/multi_wallet_converter.py
+++ b/askar_tools/multi_wallet_converter.py
@@ -3,14 +3,9 @@
 from aries_askar import Store
 
 from .error import ConversionError
+from .key_methods import KEY_METHODS
 from .pg_connection import PgConnection
 from .sqlite_connection import SqliteConnection
-
-KEY_METHODS = {
-    "KEY_DERIVATION_RAW": "RAW",
-    "KEY_DERIVATION_ARGON2I_INT": "kdf:argon2i:int",
-    "KEY_DERIVATION_ARGON2I_MOD": "kdf:argon2i:mod",
-}
 
 
 class MultiWalletConverter:
@@ -21,6 +16,7 @@ class MultiWalletConverter:
         conn: SqliteConnection | PgConnection,
         wallet_name: str,
         wallet_key: str,
+        wallet_key_derivation_method: str,
         sub_wallet_name: str,
     ):
         """Initialize the MultiWalletConverter instance.
@@ -29,11 +25,13 @@ class MultiWalletConverter:
             conn (SqliteConnection): The SQLite connection object.
             wallet_name (str): The name of the wallet.
             wallet_key (str): The key for the wallet.
+            wallet_key_derivation_method (str): The key derivation method for the wallet.
             sub_wallet_name (str): The name of the sub wallet.
         """
         self.conn = conn
         self.admin_wallet_name = wallet_name
         self.admin_wallet_key = wallet_key
+        self.wallet_key_derivation_method = wallet_key_derivation_method
         self.sub_wallet_name = sub_wallet_name
 
     def get_wallet_records(self, entries):
@@ -87,7 +85,7 @@ class MultiWalletConverter:
                 )
                 key_method = KEY_METHODS.get(
                     wallet_record["settings"].get(
-                        "wallet.key_derivation_method", "KEY_DERIVATION_ARGON2I_MOD"
+                        "wallet.key_derivation_method", "ARGON2I_MOD"
                     )
                 )
                 print(

--- a/askar_tools/pg_connection.py
+++ b/askar_tools/pg_connection.py
@@ -86,7 +86,7 @@ class PgConnection(DbConnection):
 
         return result
 
-    async def create_database(self, base_wallet_name, sub_wallet_name):
+    async def create_database(self, admin_wallet_name, sub_wallet_name):
         """Create an postgres database."""
         await self._conn.execute(
             f"""
@@ -94,7 +94,7 @@ class PgConnection(DbConnection):
             """
         )
 
-    async def remove_wallet(self, base_wallet_name, sub_wallet_name):
+    async def remove_wallet(self, admin_wallet_name, sub_wallet_name):
         """Remove the postgres wallet."""
         # Kill any connections to the database
         await self._conn.execute(

--- a/askar_tools/tenant_importer.py
+++ b/askar_tools/tenant_importer.py
@@ -1,0 +1,177 @@
+"""This module contains the Tenant Importer class."""
+
+import time
+import uuid
+
+from aries_askar import Store
+
+from .pg_connection import PgConnection
+from .sqlite_connection import SqliteConnection
+
+
+class TenantImporter:
+    """The Tenant Importer class."""
+
+    def __init__(
+        self,
+        admin_conn: SqliteConnection | PgConnection,
+        admin_wallet_name: str,
+        admin_wallet_key: str,
+        tenant_conn: SqliteConnection | PgConnection,
+        tenant_wallet_name: str,
+        tenant_wallet_key: str,
+    ):
+        """Initialize the Tenant Importer object.
+
+        Args:
+            admin_conn: The admin connection object.
+            admin_wallet_name: The name of the admin wallet.
+            admin_wallet_key: The key for the admin wallet.
+            tenant_conn: The tenant connection object.
+            tenant_wallet_name: The name of the tenant wallet.
+            tenant_wallet_key: The key for the tenant wallet.
+        """
+        self.admin_conn = admin_conn
+        self.admin_wallet_name = admin_wallet_name
+        self.admin_wallet_key = admin_wallet_key
+        self.tenant_conn = tenant_conn
+        self.tenant_wallet_name = tenant_wallet_name
+        self.tenant_wallet_key = tenant_wallet_key
+
+    async def _create_tenant(self, wallet_id: str, admin_txn, current_time: str):
+        # Create wallet record in admin wallet
+        await admin_txn.insert(
+            category="wallet_record",
+            name=wallet_id,
+            value_json={
+                "wallet_name": self.tenant_wallet_name,
+                "created_at": current_time,
+                "updated_at": current_time,
+                "settings": {
+                    "wallet.type": "askar",
+                    "wallet.name": self.tenant_wallet_name,
+                    "wallet.key": self.tenant_wallet_key,
+                    "wallet.id": wallet_id,
+                    "wallet.dispatch_type": "base",
+                },
+                "key_management_mode": "managed",
+                "jwt_iat": current_time,
+            },
+            tags={
+                "wallet_name": self.tenant_wallet_name,
+            },
+        )
+
+    async def _create_forward_routes(
+        self, tenant_wallet: Store, admin_txn, wallet_id: str, current_time: str
+    ):
+        # Import DIDs, connections, and DID keys in forward route table
+        tenant_did_scan = tenant_wallet.scan(category="did")
+        tenant_dids = await tenant_did_scan.fetch_all()
+        for did in tenant_dids:
+            print(f"Importing DID: {did.value_json}")
+            await admin_txn.insert(
+                category="forward_route",
+                name=str(uuid.uuid4()),
+                value_json={
+                    "recipient_key": did.value_json["verkey"],
+                    "wallet_id": wallet_id,
+                    "created_at": current_time,
+                    "updated_at": current_time,
+                    "connection_id": None,
+                },
+                tags={
+                    "recipient_key": did.value_json["verkey"],
+                    "role": "server",
+                    "wallet_id": wallet_id,
+                },
+            )
+        tenant_connection_scan = tenant_wallet.scan(category="connection")
+        tenant_connections = await tenant_connection_scan.fetch_all()
+        for connection in tenant_connections:
+            print(f"Importing connection: {connection.value_json}")
+            await admin_txn.insert(
+                category="forward_route",
+                name=str(uuid.uuid4()),
+                value_json={
+                    "recipient_key": connection.value_json["invitation_key"],
+                    "wallet_id": wallet_id,
+                    "created_at": current_time,
+                    "updated_at": current_time,
+                    "connection_id": None,
+                },
+                tags={
+                    "recipient_key": connection.value_json["invitation_key"],
+                    "role": "server",
+                    "wallet_id": wallet_id,
+                },
+            )
+        tenant_did_key_scan = tenant_wallet.scan(category="did_key")
+        tenant_did_keys = await tenant_did_key_scan.fetch_all()
+        for did_key in tenant_did_keys:
+            print(f"Importing did key: {did_key.value}")
+            await admin_txn.insert(
+                category="forward_route",
+                name=str(uuid.uuid4()),
+                value_json={
+                    "recipient_key": did_key.tags["key"],
+                    "wallet_id": wallet_id,
+                    "created_at": current_time,
+                    "updated_at": current_time,
+                    "connection_id": None,
+                },
+                tags={
+                    "recipient_key": did_key.tags["key"],
+                    "role": "server",
+                    "wallet_id": wallet_id,
+                },
+            )
+
+    async def import_tenant(self):
+        """Import the tenant wallet into the admin wallet."""
+        print("Importing tenant wallet into admin wallet")
+
+        # Make wallet/db in admin location for tenant
+        await self.admin_conn.create_database(
+            admin_wallet_name=self.admin_wallet_name,
+            sub_wallet_name=self.tenant_wallet_name,
+        )
+        # Copy the tenant wallet to the admin wallet location
+        tenant_wallet = await Store.open(
+            uri=self.tenant_conn.uri,
+            pass_key=self.tenant_wallet_key,
+        )
+        await tenant_wallet.copy_to(
+            target_uri=self.admin_conn.uri.replace(
+                self.admin_wallet_name, self.tenant_wallet_name
+            ),
+            pass_key=self.tenant_wallet_key,
+        )
+
+        # Import the tenant wallet into the admin wallet
+        admin_store = await Store.open(
+            uri=self.admin_conn.uri,
+            pass_key=self.admin_wallet_key,
+        )
+        async with admin_store.transaction() as admin_txn:
+            wallet_id = str(uuid.uuid4())
+            current_time = time.time()
+            await self._create_tenant(
+                wallet_id=wallet_id,
+                admin_txn=admin_txn,
+                current_time=current_time,
+            )
+            await self._create_forward_routes(
+                tenant_wallet=tenant_wallet,
+                admin_txn=admin_txn,
+                wallet_id=wallet_id,
+                current_time=current_time,
+            )
+            await admin_txn.commit()
+
+        await self.admin_conn.close()
+        await self.tenant_conn.close()
+
+    async def run(self):
+        """Run the importer."""
+        await self.import_tenant()

--- a/askar_tools/tests/e2e/cases.py
+++ b/askar_tools/tests/e2e/cases.py
@@ -97,3 +97,8 @@ class MtConvertToMwTestCases(BaseTestCases):
 class ExportTestCases(BaseTestCases):
     def __init__(self):
         self._cases = (self.connections(), self.credentials_with_revocation())
+
+
+class TenantImportTestCases(BaseTestCases):
+    def __init__(self):
+        self._cases = (self.connections(), self.credentials_with_revocation())

--- a/askar_tools/tests/e2e/containers.py
+++ b/askar_tools/tests/e2e/containers.py
@@ -174,8 +174,9 @@ class Containers:
         self,
         name: str,
         wallet_key: str,
-        admin_port: int,
+        wallet_key_derivation_method: str,
         wallet_type: str,
+        admin_port: int,
         volume_src: str,
         volume_dst: str,
         sub_wallet_src: Optional[str] = None,
@@ -198,6 +199,7 @@ class Containers:
                     --wallet-type {wallet_type}
                     --wallet-name {name}
                     --wallet-key {wallet_key}
+                    --wallet-key-derivation-method {wallet_key_derivation_method}
                     --preserve-exchange-records
                     --auto-provision
             """
@@ -239,8 +241,9 @@ class Containers:
         self,
         name: str,
         wallet_key: str,
-        admin_port: int,
+        wallet_key_derivation_method: str,
         wallet_type: str,
+        admin_port: int,
         postgres: Container,
         mwst: bool = False,
         mt: bool = False,
@@ -261,6 +264,7 @@ class Containers:
                 --wallet-type {wallet_type}
                 --wallet-name {name}
                 --wallet-key {wallet_key}
+                --wallet-key-derivation-method {wallet_key_derivation_method}
                 --wallet-storage-type postgres_storage
                 --preserve-exchange-records
                 --auto-provision

--- a/askar_tools/tests/e2e/containers.py
+++ b/askar_tools/tests/e2e/containers.py
@@ -99,11 +99,13 @@ class Containers:
         self.containers.remove(container)
         container.stop()
 
-    def postgres(self, port: int, volume: Optional[str] = None) -> Container:
+    def postgres(
+        self, port: int, volume: Optional[str] = None, name: Optional[str] = "postgres"
+    ) -> Container:
         """Create a postgres container."""
         container = self.client.containers.run(
             self.POSTGRES_IMAGE,
-            name="postgres",
+            name=name,
             volumes={volume: {"bind": "/var/lib/postgresql/data", "mode": "rw,z"}}
             if volume
             else None,

--- a/askar_tools/tests/e2e/test_mt_convert_to_mw.py
+++ b/askar_tools/tests/e2e/test_mt_convert_to_mw.py
@@ -8,7 +8,7 @@ from .cases import MtConvertToMwTestCases
 from .containers import Containers
 
 
-class TestPgMtConvertToMw(WalletTypeToBeTested):
+class TestMultitenantConvertToMultiwallet(WalletTypeToBeTested):
     @pytest.mark.asyncio
     @pytest.mark.e2e
     async def test_conversion_pg(self, containers: Containers):

--- a/askar_tools/tests/e2e/test_mt_convert_to_mw.py
+++ b/askar_tools/tests/e2e/test_mt_convert_to_mw.py
@@ -18,8 +18,9 @@ class TestMultitenantConvertToMultiwallet(WalletTypeToBeTested):
         admin_container = containers.acapy_postgres(
             "admin",
             "insecure",
-            3001,
+            "kdf:argon2i:mod",
             "askar",
+            3001,
             postgres,
             mwst=True,
             mt=True,
@@ -35,7 +36,8 @@ class TestMultitenantConvertToMultiwallet(WalletTypeToBeTested):
                 json={
                     "label": "Alice",
                     "wallet_name": "alice",
-                    "wallet_key": "alice_insecure1",
+                    "wallet_key": "3cAZj1hPvUhKeBkzCKPTHhTxRRmYv5abDbjmaYwtk6Nf",
+                    "wallet_key_derivation": "RAW",
                     "wallet_type": "askar",
                 },
                 response=CreateWalletResponse,
@@ -77,8 +79,9 @@ class TestMultitenantConvertToMultiwallet(WalletTypeToBeTested):
         admin_container = containers.acapy_postgres(
             "admin",
             "insecure",
-            3001,
+            "kdf:argon2i:mod",
             "askar",
+            3001,
             postgres,
             mt=True,
             askar_profile=False,
@@ -114,8 +117,9 @@ class TestMultitenantConvertToMultiwallet(WalletTypeToBeTested):
         admin_container = containers.acapy_sqlite(
             "admin",
             "insecure",
-            3001,
+            "kdf:argon2i:mod",
             "askar",
+            3001,
             admin_volume_path,
             "/home/aries/.aries_cloudagent/wallet/admin",
             sub_wallet_volume_path,
@@ -133,7 +137,8 @@ class TestMultitenantConvertToMultiwallet(WalletTypeToBeTested):
                 json={
                     "label": "Alice",
                     "wallet_name": "alice",
-                    "wallet_key": "alice_insecure1",
+                    "wallet_key": "3cAZj1hPvUhKeBkzCKPTHhTxRRmYv5abDbjmaYwtk6Nf",
+                    "wallet_key_derivation": "RAW",
                     "wallet_type": "askar",
                 },
                 response=CreateWalletResponse,

--- a/askar_tools/tests/e2e/test_tenant_import.py
+++ b/askar_tools/tests/e2e/test_tenant_import.py
@@ -1,0 +1,109 @@
+import pytest
+from acapy_controller import Controller
+from acapy_controller.models import CreateWalletResponse
+from askar_tools.__main__ import main
+
+from . import WalletTypeToBeTested
+from .cases import TenantImportTestCases
+from .containers import Containers
+
+
+class TestTenantImport(WalletTypeToBeTested):
+    @pytest.mark.asyncio
+    @pytest.mark.e2e
+    async def test_tenant_import_pg(self, containers: Containers):
+        # Prepare
+        admin_postgres = containers.postgres(5432, name="admin_postgres")
+        tenant_postgres = containers.postgres(5433, name="tenant_postgres")
+        # Create an admin container with a single wallet
+        admin_container = containers.acapy_postgres(
+            "admin",
+            "insecure",
+            3001,
+            "askar",
+            admin_postgres,
+            mwst=True,
+            mt=True,
+            askar_profile=False,
+        )
+        tenant_container = containers.acapy_postgres(
+            "tenant",
+            "insecure",
+            3002,
+            "askar",
+            tenant_postgres,
+            mwst=False,
+            mt=False,
+        )
+        containers.wait_until_healthy(admin_container)
+        containers.wait_until_healthy(tenant_container)
+
+        async with Controller("http://localhost:3001") as admin:
+            test_cases = TenantImportTestCases()
+            # Create sub wallet with admin
+            alice_wallet = await admin.post(
+                "/multitenancy/wallet",
+                json={
+                    "label": "Alice",
+                    "wallet_name": "alice",
+                    "wallet_key": "alice_insecure1",
+                    "wallet_type": "askar",
+                },
+                response=CreateWalletResponse,
+            )
+
+            # Start the alice subwallet controller and create the separate db tenant controller
+            async with Controller(
+                "http://localhost:3001",
+                wallet_id=alice_wallet.wallet_id,
+                subwallet_token=alice_wallet.token,
+            ) as alice, Controller(
+                "http://localhost:3002",
+            ) as tenant:
+                await test_cases.pre(alice, tenant)
+
+        # Action the import
+        await main(
+            strategy="tenant-import",
+            uri="postgres://postgres:mysecretpassword@localhost:5432/admin",
+            wallet_name="admin",
+            wallet_key="insecure",
+            tenant_uri="postgres://postgres:mysecretpassword@localhost:5433/tenant",
+            tenant_wallet_name="tenant",
+            tenant_wallet_key="insecure",
+        )
+
+        async with Controller("http://localhost:3001") as admin:
+            # Get the tenant wallet id and token
+            wallets = await admin.get("/multitenancy/wallets")
+
+            tenant_wallet_id = None
+            for wallet in wallets["results"]:
+                if wallet["settings"]["wallet.name"] == "tenant":
+                    tenant_wallet_id = wallet["wallet_id"]
+                    break
+            assert tenant_wallet_id is not None
+
+            tenant_wallet_token = (
+                await admin.post(f"/multitenancy/wallet/{tenant_wallet_id}/token")
+            )["token"]
+
+            assert tenant_wallet_token is not None
+
+            # Re-run the test cases with the new tenant wallet
+            test_cases = TenantImportTestCases()
+            async with Controller(
+                "http://localhost:3001",
+                wallet_id=alice_wallet.wallet_id,
+                subwallet_token=alice_wallet.token,
+            ) as alice, Controller(
+                "http://localhost:3001",
+                wallet_id=tenant_wallet_id,
+                subwallet_token=tenant_wallet_token,
+            ) as tenant:
+                await test_cases.pre(alice, tenant)
+
+        containers.stop(admin_container)
+        containers.stop(admin_postgres)
+        containers.stop(tenant_container)
+        containers.stop(tenant_postgres)

--- a/askar_tools/tests/e2e/test_tenant_import.py
+++ b/askar_tools/tests/e2e/test_tenant_import.py
@@ -19,8 +19,9 @@ class TestTenantImport(WalletTypeToBeTested):
         admin_container = containers.acapy_postgres(
             "admin",
             "insecure",
-            3001,
+            "kdf:argon2i:mod",
             "askar",
+            3001,
             admin_postgres,
             mwst=True,
             mt=True,
@@ -28,9 +29,10 @@ class TestTenantImport(WalletTypeToBeTested):
         )
         tenant_container = containers.acapy_postgres(
             "tenant",
-            "insecure",
-            3002,
+            "3cAZj1hPvUhKeBkzCKPTHhTxRRmYv5abDbjmaYwtk6Nf",
+            "RAW",
             "askar",
+            3002,
             tenant_postgres,
             mwst=False,
             mt=False,
@@ -70,7 +72,13 @@ class TestTenantImport(WalletTypeToBeTested):
             wallet_key="insecure",
             tenant_uri="postgres://postgres:mysecretpassword@localhost:5433/tenant",
             tenant_wallet_name="tenant",
-            tenant_wallet_key="insecure",
+            tenant_wallet_key="3cAZj1hPvUhKeBkzCKPTHhTxRRmYv5abDbjmaYwtk6Nf",
+            tenant_label="Tenant",
+            tenant_image_url="https://example.com/image.png",
+            tenant_extra_settings={"extra": "settings"},
+            tenant_webhook_urls=["http://example.com/webhook"],
+            tenant_dispatch_type="default",
+            tenant_wallet_key_derivation_method="RAW",
         )
 
         async with Controller("http://localhost:3001") as admin:


### PR DESCRIPTION
Move a standalone agent from an arbitrary location into a multi-tenant multi-wallet agent.

***Only works for multi-tenant, multi-wallet agents*** 

Copies the standalone database to the location next to the admin wallet and then creates the wallet records and forward route mappings for the connection and did keys.

Should allow all the configs available through the api when creating a sub wallet to be declared from the command line. 

Adds raw key support to this tool and the existing tools.

Tests it fairly well with automated testing, but only with postgres. sqlite is quite complicated for restarting agents. Creates an admin agent and a standalone on 2 different instances and volumes. Creates connection and a credentials flow through issuance and revocation. Runs the migration and then reruns the same flow with the existing connection.

***Potential problems:***
- Is there possibly keys that need a foward route I don't know about and haven't tested?
- passwords and security during migrations

Adds a couple other, not important features to the existing tools.