### PR TITLE
feat: Credo mediator clean up cron job

### DIFF
--- a/askar_tools/README.md
+++ b/askar_tools/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites:
 
- * Wallet(s) must be of type askar.
+* Wallet(s) must be of type askar.
 
 ## Install
 
@@ -95,14 +95,16 @@ poetry install
  * The tool will delete records that are older than the specified number of days.
  * The tool will run indefinitely until it is stopped.
  * The tool will wait until the specified start time before starting the first cleanup.
-- `credo-mediator-clean-up` (Clean up old records from the credo mediator wallet):
+- `mediator-cleanup` (Clean up old records from the credo mediator wallet):
     ```
     poetry run askar-tools \
-    --strategy credo-mediator-clean-up \
+    --strategy mediator-cleanup \
     --uri postgres://<username>:<password>@<hostname>:<port>/<dbname> \
+    --pickup-repository-uri postgres://<username>:<password>@<hostname>:<port>/<dbname> \
     --wallet-name <base wallet name> \
     --wallet-key <base wallet key> \
     --inactive-days-threshold <number of days after which a connection is considered inactive> \
     --cron-job-start-time <optional: start time for the cron job in ISO format, default is now> \
     --cron-job-interval-days <optional: number of days between each cleanup, default is 7>
+    
     ```

--- a/askar_tools/README.md
+++ b/askar_tools/README.md
@@ -88,3 +88,21 @@ poetry install
     --wallet-name <base wallet name> \
     --wallet-key <base wallet key> 
     ```
+
+### Credo Mediator Clean Up:
+
+ * This tool is designed to run as a cron job to clean up old records from the credo mediator wallet.
+ * The tool will delete records that are older than the specified number of days.
+ * The tool will run indefinitely until it is stopped.
+ * The tool will wait until the specified start time before starting the first cleanup.
+- `credo-mediator-clean-up` (Clean up old records from the credo mediator wallet):
+    ```
+    poetry run askar-tools \
+    --strategy credo-mediator-clean-up \
+    --uri postgres://<username>:<password>@<hostname>:<port>/<dbname> \
+    --wallet-name <base wallet name> \
+    --wallet-key <base wallet key> \
+    --inactive-days-threshold <number of days after which a connection is considered inactive> \
+    --cron-job-start-time <optional: start time for the cron job in ISO format, default is now> \
+    --cron-job-interval-days <optional: number of days between each cleanup, default is 7>
+    ```

--- a/askar_tools/__main__.py
+++ b/askar_tools/__main__.py
@@ -7,15 +7,14 @@ import sys
 from datetime import datetime, timezone
 from urllib.parse import urlparse
 
+from askar_tools.credo_mediator_clean_up import CredoMediatorCleanUp
+from askar_tools.error import InvalidArgumentsError
 from askar_tools.exporter import Exporter
 from askar_tools.mediator_converter import MediatorConverter
 from askar_tools.multi_wallet_converter import MultiWalletConverter
 from askar_tools.pg_connection import PgConnection
 from askar_tools.sqlite_connection import SqliteConnection
 from askar_tools.tenant_importer import TenantImporter, TenantImportObject
-
-from .credo_mediator_clean_up import CredoMediatorCleanUp
-from .error import InvalidArgumentsError
 
 
 def config():
@@ -259,9 +258,9 @@ async def main(args):
             conn=conn,
             wallet_name=args.wallet_name,
             wallet_key=args.wallet_key,
+            cron_job_start_time=datetime.fromisoformat(args.cron_job_start_time) if args.cron_job_start_time else datetime.now(timezone.utc),
             wallet_key_derivation_method=args.wallet_key_derivation_method,
             inactive_days_threshold=args.inactive_days_threshold,
-            cron_job_start_time=datetime.fromisoformat(args.cron_job_start_time) if args.cron_job_start_time else datetime.now(timezone.utc),
             cron_job_interval_days=args.cron_job_interval_days,
         )
     else:

--- a/askar_tools/__main__.py
+++ b/askar_tools/__main__.py
@@ -17,6 +17,17 @@ from askar_tools.sqlite_connection import SqliteConnection
 from askar_tools.tenant_importer import TenantImporter, TenantImportObject
 
 
+def parse_iso_datetime(value: str) -> datetime:
+    """Parse an ISO datetime string and ensure the result is timezone-aware."""
+    normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+    parsed = datetime.fromisoformat(normalized)
+
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+
+    return parsed
+
+
 def config():
     """Parse command line arguments."""
     parser = argparse.ArgumentParser("askar-wallet-tools")
@@ -261,14 +272,15 @@ async def main(args):
         if not args.pickup_repository_uri:
             raise ValueError("--pickup-repository-uri is required for mediator-cleanup strategy")
         pickup_repo_conn = PgConnection(args.pickup_repository_uri)
-        await pickup_repo_conn.connect()
         await conn.connect()
         method = CredoMediatorCleanUp(
             conn=conn,
             pickup_repo_conn=pickup_repo_conn,
             wallet_name=args.wallet_name,
             wallet_key=args.wallet_key,
-            cron_job_start_time=datetime.fromisoformat(args.cron_job_start_time) if args.cron_job_start_time else datetime.now(timezone.utc),
+            cron_job_start_time=parse_iso_datetime(args.cron_job_start_time)
+            if args.cron_job_start_time
+            else datetime.now(timezone.utc),
             wallet_key_derivation_method=args.wallet_key_derivation_method,
             inactive_days_threshold=args.inactive_days_threshold,
             cron_job_interval_days=args.cron_job_interval_days,

--- a/askar_tools/__main__.py
+++ b/askar_tools/__main__.py
@@ -4,15 +4,18 @@ import argparse
 import asyncio
 import logging
 import sys
+from datetime import datetime, timezone
 from urllib.parse import urlparse
 
-from askar_tools.error import InvalidArgumentsError
 from askar_tools.exporter import Exporter
 from askar_tools.mediator_converter import MediatorConverter
 from askar_tools.multi_wallet_converter import MultiWalletConverter
 from askar_tools.pg_connection import PgConnection
 from askar_tools.sqlite_connection import SqliteConnection
 from askar_tools.tenant_importer import TenantImporter, TenantImportObject
+
+from .credo_mediator_clean_up import CredoMediatorCleanUp
+from .error import InvalidArgumentsError
 
 
 def config():
@@ -23,7 +26,7 @@ def config():
     parser.add_argument(
         "--strategy",
         required=True,
-        choices=["export", "mt-convert-to-mw", "tenant-import", "mediator-convert"],
+        choices=["export", "mt-convert-to-mw", "tenant-import", "mediator-convert", "mediator-cleanup"],
         help=(
             "Specify migration strategy depending on database type, wallet "
             "management mode, and agent type."
@@ -140,6 +143,33 @@ def config():
         help=("Specify the dispatch type for the tenant wallet."),
         default="base",
     )
+    
+    parser.add_argument(
+        "--inactive-days-threshold",
+        type=int,
+        help=(
+            "Specify the number of days after which a connection is considered "
+            "inactive for the mediator cleanup strategy. Default is 365 days."
+        ),
+        default=365,
+    )
+    parser.add_argument(
+        "--cron-job-start-time",
+        type=str,
+        help=(
+            "Specify the start time for the cron job in ISO format (e.g., "
+            "2026-02-24T00:00:00Z) for the mediator cleanup strategy. Default is the current time."
+        ),
+    )
+    parser.add_argument(
+        "--cron-job-interval-days",
+        type=int,
+        help=(
+            "Specify the interval in days between cron job executions for the "
+            "mediator cleanup strategy. Default is 7 days."
+        ),
+        default=7,
+    )
 
     args, _ = parser.parse_known_args(sys.argv[1:])
 
@@ -222,6 +252,17 @@ async def main(args):
             conn=conn,
             wallet_name=args.wallet_name,
             wallet_key=args.wallet_key,
+        )
+    elif args.strategy == "mediator-cleanup":
+        await conn.connect()
+        method = CredoMediatorCleanUp(
+            conn=conn,
+            wallet_name=args.wallet_name,
+            wallet_key=args.wallet_key,
+            wallet_key_derivation_method=args.wallet_key_derivation_method,
+            inactive_days_threshold=args.inactive_days_threshold,
+            cron_job_start_time=datetime.fromisoformat(args.cron_job_start_time) if args.cron_job_start_time else datetime.now(timezone.utc),
+            cron_job_interval_days=args.cron_job_interval_days,
         )
     else:
         raise InvalidArgumentsError("Invalid strategy")

--- a/askar_tools/__main__.py
+++ b/askar_tools/__main__.py
@@ -169,6 +169,11 @@ def config():
         ),
         default=7,
     )
+    parser.add_argument(
+        "--pickup-repository-uri",
+        type=str,
+        help=("Specify the URI of the pickup repository for the mediator cleanup strategy."),
+    )
 
     args, _ = parser.parse_known_args(sys.argv[1:])
 
@@ -253,9 +258,14 @@ async def main(args):
             wallet_key=args.wallet_key,
         )
     elif args.strategy == "mediator-cleanup":
+        if not args.pickup_repository_uri:
+            raise ValueError("--pickup-repository-uri is required for mediator-cleanup strategy")
+        pickup_repo_conn = PgConnection(args.pickup_repository_uri)
+        await pickup_repo_conn.connect()
         await conn.connect()
         method = CredoMediatorCleanUp(
             conn=conn,
+            pickup_repo_conn=pickup_repo_conn,
             wallet_name=args.wallet_name,
             wallet_key=args.wallet_key,
             cron_job_start_time=datetime.fromisoformat(args.cron_job_start_time) if args.cron_job_start_time else datetime.now(timezone.utc),

--- a/askar_tools/credo_mediator_clean_up.py
+++ b/askar_tools/credo_mediator_clean_up.py
@@ -4,6 +4,7 @@
 import asyncio
 from datetime import datetime, timedelta, timezone
 
+import asyncpg
 from aries_askar import Store
 
 from .key_methods import KEY_METHODS
@@ -17,6 +18,7 @@ class CredoMediatorCleanUp:
     def __init__(
         self,
         conn: SqliteConnection | PgConnection,
+        pickup_repo_conn: PgConnection,
         wallet_name: str,
         wallet_key: str,
         cron_job_start_time: datetime,
@@ -36,6 +38,7 @@ class CredoMediatorCleanUp:
             cron_job_interval_days: The interval in days between cron job executions.
         """
         self.conn = conn
+        self.pickup_repo_conn = pickup_repo_conn
         self.wallet_name = wallet_name
         self.wallet_key = wallet_key
         self.wallet_key_derivation_method = wallet_key_derivation_method
@@ -55,48 +58,62 @@ class CredoMediatorCleanUp:
             key_method=KEY_METHODS.get(self.wallet_key_derivation_method),
         )
         
+        db_conn = await asyncpg.connect(
+            host=self.pickup_repo_conn.parsed_url.hostname,
+            port=self.pickup_repo_conn.parsed_url.port or 5432,
+            user=self.pickup_repo_conn.parsed_url.username,
+            password=self.pickup_repo_conn.parsed_url.password,
+            database=self.pickup_repo_conn.parsed_url.path.lstrip("/"),
+            )
+        
+        connections_with_queued_messages = await db_conn.fetch("SELECT DISTINCT connection_id FROM queued_message")
+        
+        connections_with_queued_messages = {str(record["connection_id"]) for record in connections_with_queued_messages} 
+                
         async with store.transaction() as session:
             connection_records = await session.fetch_all("ConnectionRecord")
             
         deleted = 0
         for connection_record in connection_records:
-            used_for_mediation = connection_record.value_json.get("metadata", {}).get("_internal/useDidKeysForProtocol", {}).get("https://didcomm.org/coordinate-mediation/1.0", False)
-            if used_for_mediation:
-                async with store.transaction() as txn:
-                    try:
-                        last_seen_time = connection_record.value_json.get("tags", {}).get("lastSeen")
+            async with store.transaction() as txn:
+                try:
+                    if connection_record.name in connections_with_queued_messages:
+                        print(f"Skipping connection record with id {connection_record.name} because it has queued messages")
+                        continue
+                    
+                    last_seen_time = connection_record.value_json.get("tags", {}).get("lastSeen")
+                    
+                    if last_seen_time is None and now - self.cron_job_start_time > timedelta(days=self.inactive_days_threshold):
+                        last_seen_time = connection_record.value_json.get("updatedAt")
+                    
+                    if last_seen_time and now - datetime.fromisoformat(last_seen_time.replace("Z", "+00:00")) > timedelta(days=self.inactive_days_threshold):
+                        their_did = connection_record.value_json.get("theirDid")
+                        their_did_record = None
+                        did = connection_record.value_json.get("did")
+                        did_record = None
                         
-                        if last_seen_time is None and now - self.cron_job_start_time > timedelta(days=self.inactive_days_threshold):
-                            last_seen_time = connection_record.value_json.get("updatedAt")
-                        
-                        if last_seen_time and now - datetime.fromisoformat(last_seen_time.replace("Z", "+00:00")) > timedelta(days=self.inactive_days_threshold):
-                            their_did = connection_record.value_json.get("theirDid")
-                            their_did_record = None
-                            did = connection_record.value_json.get("did")
-                            did_record = None
+                        await txn.remove("ConnectionRecord", connection_record.name)
+                        if their_did:
+                            their_did_record = await txn.fetch_all("DidRecord", tag_filter={"did": their_did}, limit=1)
                             
-                            await txn.remove("ConnectionRecord", connection_record.name)
-                            if their_did:
-                                their_did_record = await txn.fetch_all("DidRecord", tag_filter={"did": their_did}, limit=1)
-                                
-                            if did:
-                                did_record = await txn.fetch_all("DidRecord", tag_filter={"did": did}, limit=1)
-                            mediation_record = await txn.fetch_all("MediationRecord", tag_filter={"connectionId": connection_record.name}, limit=1)
-                            firebase_record = await txn.fetch_all("PushNotificationsFcmRecord", tag_filter={"connectionId": connection_record.name}, limit=1)
-                            if their_did_record:
-                                await txn.remove("DidRecord", their_did_record[0].name)
-                            if did_record:
-                                await txn.remove("DidRecord", did_record[0].name)
-                            if mediation_record:
-                                await txn.remove("MediationRecord", mediation_record[0].name)
-                            if firebase_record:
-                                await txn.remove("PushNotificationsFcmRecord", firebase_record[0].name)
-                            deleted += 1
-                            print(f"Deleted connection record with id {connection_record.name} last seen at {last_seen_time} and associated records")
-                    except Exception as e:
-                        print(f"Error processing connection record with id {connection_record.name}: {e}")
-                        await txn.rollback()
-                    await txn.commit()
+                        if did:
+                            did_record = await txn.fetch_all("DidRecord", tag_filter={"did": did}, limit=1)
+                        mediation_record = await txn.fetch_all("MediationRecord", tag_filter={"connectionId": connection_record.name}, limit=1)
+                        firebase_record = await txn.fetch_all("PushNotificationsFcmRecord", tag_filter={"connectionId": connection_record.name}, limit=1)
+                        if their_did_record:
+                            await txn.remove("DidRecord", their_did_record[0].name)
+                        if did_record:
+                            await txn.remove("DidRecord", did_record[0].name)
+                        if mediation_record:
+                            await txn.remove("MediationRecord", mediation_record[0].name)
+                        if firebase_record:
+                            await txn.remove("PushNotificationsFcmRecord", firebase_record[0].name)
+                        deleted += 1
+                        print(f"Deleted connection record with id {connection_record.name} last seen at {last_seen_time} and associated records")
+                except Exception as e:
+                    print(f"Error processing connection record with id {connection_record.name}: {e}")
+                    await txn.rollback()
+                await txn.commit()
                         
         print(f"Cleanup complete. Deleted {deleted} connection and related records.")
         await store.close()

--- a/askar_tools/credo_mediator_clean_up.py
+++ b/askar_tools/credo_mediator_clean_up.py
@@ -23,6 +23,11 @@ def parse_iso_datetime(value: str) -> datetime:
     return parsed
 
 
+def format_utc_datetime(value: datetime) -> str:
+    """Format a timezone-aware datetime as an ISO 8601 UTC string."""
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
 def get_connection_activity_time(
     connection_value: dict, connection_tags: dict | None = None
 ) -> datetime | None:
@@ -118,6 +123,22 @@ class CredoMediatorCleanUp:
                     activity_time = get_connection_activity_time(
                         connection_record.value_json, connection_record.tags
                     )
+
+                    if activity_time is None:
+                        connection_value = dict(connection_record.value_json)
+                        connection_value["updatedAt"] = format_utc_datetime(now)
+                        await txn.replace(
+                            "ConnectionRecord",
+                            connection_record.name,
+                            value_json=connection_value,
+                            tags=connection_record.tags,
+                        )
+                        print(
+                            f"Backfilled updatedAt for connection record with id {connection_record.name} "
+                            f"to {connection_value['updatedAt']}"
+                        )
+                        await txn.commit()
+                        continue
 
                     if activity_time and now - activity_time > timedelta(days=self.inactive_days_threshold):
                         their_did = connection_record.value_json.get("theirDid")

--- a/askar_tools/credo_mediator_clean_up.py
+++ b/askar_tools/credo_mediator_clean_up.py
@@ -1,0 +1,121 @@
+"""This module contains the Exporter class."""
+
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+from aries_askar import Store
+
+from .key_methods import KEY_METHODS
+from .pg_connection import PgConnection
+from .sqlite_connection import SqliteConnection
+
+
+class CredoMediatorCleanUp:
+    """The CredoMediatorCleanUp class."""
+
+    def __init__(
+        self,
+        conn: SqliteConnection | PgConnection,
+        wallet_name: str,
+        wallet_key: str,
+        wallet_key_derivation_method: str = "ARGON2I_MOD",
+        inactive_days_threshold: int = 365,
+        cron_job_start_time: datetime = datetime.now(timezone.utc),
+        cron_job_interval_days: int = 7,
+    ):
+        """Initialize the CredoMediatorCleanUp object.
+
+        Args:
+            conn: The connection object.
+            wallet_name: The name of the wallet.
+            wallet_key: The key for the wallet.
+            wallet_key_derivation_method: The key derivation method for the wallet.
+            inactive_days_threshold: The number of days after which a connection is considered inactive.
+            cron_job_start_time: The time when the cron job starts.
+            cron_job_interval_days: The interval in days between cron job executions.
+        """
+        self.conn = conn
+        self.wallet_name = wallet_name
+        self.wallet_key = wallet_key
+        self.wallet_key_derivation_method = wallet_key_derivation_method
+        self.inactive_days_threshold = inactive_days_threshold
+        self.cron_job_start_time = cron_job_start_time
+        self.cron_job_interval_days = cron_job_interval_days
+        
+    async def cleanup(self):
+        """Clean up the wallet data."""
+        print("Cleaning up wallet...")
+        
+        now = datetime.now(timezone.utc)
+
+        store = await Store.open(
+            self.conn.uri,
+            pass_key=self.wallet_key,
+            key_method=KEY_METHODS.get(self.wallet_key_derivation_method),
+        )
+        
+        async with store.transaction() as session:
+            connection_records = await session.fetch_all("ConnectionRecord")
+            
+        deleted = 0
+        for connection_record in connection_records:
+            used_for_mediation = connection_record.value_json.get("metadata", {}).get("_internal/useDidKeysForProtocol", {}).get("https://didcomm.org/coordinate-mediation/1.0", False)
+            if used_for_mediation:
+                async with store.transaction() as txn:
+                    try:
+                        last_seen_time = connection_record.value_json.get("tags", {}).get("lastSeen")
+                        
+                        if last_seen_time is None:
+                            last_seen_time = connection_record.value_json.get("updatedAt")
+                        
+                        
+                        if now - datetime.fromisoformat(last_seen_time.replace("Z", "+00:00")) > timedelta(days=self.inactive_days_threshold):
+                            their_did = connection_record.value_json.get("theirDid")
+                            their_did_record = None
+                            did = connection_record.value_json.get("did")
+                            did_record = None
+                            
+                            print(f"Deleting connection record with id {connection_record.name} last seen at {last_seen_time}")
+                            await txn.remove("ConnectionRecord", connection_record.name)
+                            if their_did:
+                                their_did_record = await txn.fetch_all("DidRecord", tag_filter={"did": their_did}, limit=1)
+                                
+                            if did:
+                                did_record = await txn.fetch_all("DidRecord", tag_filter={"did": did}, limit=1)
+                            mediation_record = await txn.fetch_all("MediationRecord", tag_filter={"connectionId": connection_record.name}, limit=1)
+                            firebase_record = await txn.fetch_all("PushNotificationsFcmRecord", tag_filter={"connectionId": connection_record.name}, limit=1)
+                            if their_did_record:
+                                await txn.remove("DidRecord", their_did_record[0].name)
+                            if did_record:
+                                await txn.remove("DidRecord", did_record[0].name)
+                            if mediation_record:
+                                await txn.remove("MediationRecord", mediation_record[0].name)
+                            if firebase_record:
+                                await txn.remove("PushNotificationsFcmRecord", firebase_record[0].name)
+                            print(f"Deleted connection record with id {connection_record.name} and associated records")
+                            deleted += 1
+                            await txn.commit()
+                    except Exception as e:
+                        print(f"Error processing connection record with id {connection_record.name}: {e}")
+                        await txn.rollback()
+                        
+        print(f"Cleanup complete. Deleted {deleted} connection and related records.")
+        await store.close()
+        await self.conn.close()
+
+    async def run(self):
+        """Run the cleanup."""
+        
+        print(f"Waiting for cron job to start at {self.cron_job_start_time.isoformat()}...")
+        while datetime.now(timezone.utc) < self.cron_job_start_time:
+            print(".", end="", flush=True)
+            await asyncio.sleep(60)  # Sleep for 1 minute until the start time is reached
+        
+        next_run = self.cron_job_start_time
+        while True:
+            print(f"Starting cleanup at {datetime.now(timezone.utc).isoformat()}")
+            await self.cleanup()
+            next_run += timedelta(days=self.cron_job_interval_days)
+            print(f"Next cleanup scheduled at {next_run.isoformat()}")
+            await asyncio.sleep((next_run - datetime.now(timezone.utc)).total_seconds())

--- a/askar_tools/credo_mediator_clean_up.py
+++ b/askar_tools/credo_mediator_clean_up.py
@@ -1,4 +1,4 @@
-"""This module contains the Exporter class."""
+"""This module contains the CredoMediatorCleanUp class."""
 
 
 import asyncio
@@ -19,9 +19,9 @@ class CredoMediatorCleanUp:
         conn: SqliteConnection | PgConnection,
         wallet_name: str,
         wallet_key: str,
+        cron_job_start_time: datetime,
         wallet_key_derivation_method: str = "ARGON2I_MOD",
         inactive_days_threshold: int = 365,
-        cron_job_start_time: datetime = datetime.now(timezone.utc),
         cron_job_interval_days: int = 7,
     ):
         """Initialize the CredoMediatorCleanUp object.
@@ -66,17 +66,15 @@ class CredoMediatorCleanUp:
                     try:
                         last_seen_time = connection_record.value_json.get("tags", {}).get("lastSeen")
                         
-                        if last_seen_time is None:
+                        if last_seen_time is None and now - self.cron_job_start_time > timedelta(days=self.inactive_days_threshold):
                             last_seen_time = connection_record.value_json.get("updatedAt")
                         
-                        
-                        if now - datetime.fromisoformat(last_seen_time.replace("Z", "+00:00")) > timedelta(days=self.inactive_days_threshold):
+                        if last_seen_time and now - datetime.fromisoformat(last_seen_time.replace("Z", "+00:00")) > timedelta(days=self.inactive_days_threshold):
                             their_did = connection_record.value_json.get("theirDid")
                             their_did_record = None
                             did = connection_record.value_json.get("did")
                             did_record = None
                             
-                            print(f"Deleting connection record with id {connection_record.name} last seen at {last_seen_time}")
                             await txn.remove("ConnectionRecord", connection_record.name)
                             if their_did:
                                 their_did_record = await txn.fetch_all("DidRecord", tag_filter={"did": their_did}, limit=1)
@@ -93,12 +91,12 @@ class CredoMediatorCleanUp:
                                 await txn.remove("MediationRecord", mediation_record[0].name)
                             if firebase_record:
                                 await txn.remove("PushNotificationsFcmRecord", firebase_record[0].name)
-                            print(f"Deleted connection record with id {connection_record.name} and associated records")
                             deleted += 1
-                            await txn.commit()
+                            print(f"Deleted connection record with id {connection_record.name} last seen at {last_seen_time} and associated records")
                     except Exception as e:
                         print(f"Error processing connection record with id {connection_record.name}: {e}")
                         await txn.rollback()
+                    await txn.commit()
                         
         print(f"Cleanup complete. Deleted {deleted} connection and related records.")
         await store.close()
@@ -117,5 +115,11 @@ class CredoMediatorCleanUp:
             print(f"Starting cleanup at {datetime.now(timezone.utc).isoformat()}")
             await self.cleanup()
             next_run += timedelta(days=self.cron_job_interval_days)
+            delay = (next_run - datetime.now(timezone.utc)).total_seconds()
             print(f"Next cleanup scheduled at {next_run.isoformat()}")
-            await asyncio.sleep((next_run - datetime.now(timezone.utc)).total_seconds())
+            
+            # This is for an edge case where the cleanup takes a long time and we are already past the next scheduled run time. 
+            # In that case, we want to run the cleanup immediately again instead of waiting for the interval duration. 
+            # This will never happen with a properly configured cron job interval and cleanup duration, but it's good to have this safeguard in place.
+            if delay > 0:
+                await asyncio.sleep(delay)

--- a/askar_tools/credo_mediator_clean_up.py
+++ b/askar_tools/credo_mediator_clean_up.py
@@ -98,6 +98,7 @@ class CredoMediatorCleanUp:
             password=self.pickup_repo_conn.parsed_url.password,
             database=self.pickup_repo_conn.parsed_url.path.lstrip("/"),
             )
+        await self.conn.connect()
         
         connections_with_queued_messages = await db_conn.fetch("SELECT DISTINCT connection_id FROM queued_message")
         

--- a/askar_tools/credo_mediator_clean_up.py
+++ b/askar_tools/credo_mediator_clean_up.py
@@ -12,6 +12,39 @@ from .pg_connection import PgConnection
 from .sqlite_connection import SqliteConnection
 
 
+def parse_iso_datetime(value: str) -> datetime:
+    """Parse an ISO datetime string and ensure the result is timezone-aware."""
+    normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+    parsed = datetime.fromisoformat(normalized)
+
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+
+    return parsed
+
+
+def get_connection_activity_time(
+    connection_value: dict, connection_tags: dict | None = None
+) -> datetime | None:
+    """Return the best available timestamp for connection staleness checks."""
+    last_seen_time = (connection_tags or {}).get("lastSeen")
+    if not last_seen_time:
+        last_seen_time = connection_value.get("_tags", {}).get("lastSeen")
+
+    if last_seen_time:
+        return parse_iso_datetime(last_seen_time)
+
+    updated_at = connection_value.get("updatedAt")
+    if updated_at:
+        return parse_iso_datetime(updated_at)
+
+    created_at = connection_value.get("createdAt")
+    if created_at:
+        return parse_iso_datetime(created_at)
+
+    return None
+
+
 class CredoMediatorCleanUp:
     """The CredoMediatorCleanUp class."""
 
@@ -80,13 +113,12 @@ class CredoMediatorCleanUp:
                     if connection_record.name in connections_with_queued_messages:
                         print(f"Skipping connection record with id {connection_record.name} because it has queued messages")
                         continue
-                    
-                    last_seen_time = connection_record.value_json.get("tags", {}).get("lastSeen")
-                    
-                    if last_seen_time is None and now - self.cron_job_start_time > timedelta(days=self.inactive_days_threshold):
-                        last_seen_time = connection_record.value_json.get("updatedAt")
-                    
-                    if last_seen_time and now - datetime.fromisoformat(last_seen_time.replace("Z", "+00:00")) > timedelta(days=self.inactive_days_threshold):
+
+                    activity_time = get_connection_activity_time(
+                        connection_record.value_json, connection_record.tags
+                    )
+
+                    if activity_time and now - activity_time > timedelta(days=self.inactive_days_threshold):
                         their_did = connection_record.value_json.get("theirDid")
                         their_did_record = None
                         did = connection_record.value_json.get("did")
@@ -109,11 +141,14 @@ class CredoMediatorCleanUp:
                         if firebase_record:
                             await txn.remove("PushNotificationsFcmRecord", firebase_record[0].name)
                         deleted += 1
-                        print(f"Deleted connection record with id {connection_record.name} last seen at {last_seen_time} and associated records")
+                        print(
+                            f"Deleted connection record with id {connection_record.name} "
+                            f"last active at {activity_time.isoformat()} and associated records"
+                        )
+                    await txn.commit()
                 except Exception as e:
                     print(f"Error processing connection record with id {connection_record.name}: {e}")
                     await txn.rollback()
-                await txn.commit()
                         
         print(f"Cleanup complete. Deleted {deleted} connection and related records.")
         await store.close()

--- a/askar_tools/tests/e2e/test_mediator_cleanup.py
+++ b/askar_tools/tests/e2e/test_mediator_cleanup.py
@@ -1,0 +1,268 @@
+from argparse import Namespace
+from datetime import datetime, timedelta, timezone
+
+import asyncpg
+import orjson
+import pytest
+from aries_askar import Store
+from askar_tools.__main__ import main
+from askar_tools.credo_mediator_clean_up import CredoMediatorCleanUp
+from askar_tools.key_methods import KEY_METHODS
+
+from . import WalletTypeToBeTested
+from .containers import Containers
+
+
+def isoformat_z(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+async def insert_record(txn, category: str, name: str, value: dict, tags: dict):
+    await txn.insert(
+        category=category,
+        name=name,
+        value=orjson.dumps(value),
+        tags=tags,
+    )
+
+
+async def seed_wallet(uri: str, wallet_key: str, wallet_key_derivation_method: str):
+    now = datetime.now(timezone.utc)
+    stale_time = isoformat_z(now - timedelta(days=400))
+    recent_time = isoformat_z(now - timedelta(days=10))
+
+    store = await Store.open(
+        uri,
+        pass_key=wallet_key,
+        key_method=KEY_METHODS[wallet_key_derivation_method],
+    )
+    try:
+        async with store.transaction() as txn:
+            await insert_record(
+                txn,
+                "ConnectionRecord",
+                "conn-stale-tag",
+                {
+                    "createdAt": stale_time,
+                    "updatedAt": stale_time,
+                    "did": "did:example:stale",
+                    "theirDid": "did:example:their-stale",
+                },
+                {"lastSeen": stale_time},
+            )
+            await insert_record(
+                txn,
+                "DidRecord",
+                "did-stale",
+                {"did": "did:example:stale", "createdAt": stale_time},
+                {"did": "did:example:stale"},
+            )
+            await insert_record(
+                txn,
+                "DidRecord",
+                "did-their-stale",
+                {"did": "did:example:their-stale", "createdAt": stale_time},
+                {"did": "did:example:their-stale"},
+            )
+            await insert_record(
+                txn,
+                "MediationRecord",
+                "mediation-stale",
+                {"connectionId": "conn-stale-tag", "createdAt": stale_time},
+                {"connectionId": "conn-stale-tag"},
+            )
+            await insert_record(
+                txn,
+                "PushNotificationsFcmRecord",
+                "fcm-stale",
+                {"connectionId": "conn-stale-tag", "updatedAt": stale_time},
+                {"connectionId": "conn-stale-tag"},
+            )
+
+            await insert_record(
+                txn,
+                "ConnectionRecord",
+                "conn-queued",
+                {
+                    "createdAt": stale_time,
+                    "updatedAt": stale_time,
+                    "did": "did:example:queued",
+                },
+                {"lastSeen": stale_time},
+            )
+
+            await insert_record(
+                txn,
+                "ConnectionRecord",
+                "conn-fresh",
+                {
+                    "createdAt": stale_time,
+                    "updatedAt": recent_time,
+                    "did": "did:example:fresh",
+                },
+                {"lastSeen": recent_time},
+            )
+
+            await insert_record(
+                txn,
+                "ConnectionRecord",
+                "conn-updated-fallback",
+                {
+                    "createdAt": recent_time,
+                    "updatedAt": stale_time,
+                    "did": "did:example:updated-fallback",
+                },
+                {},
+            )
+
+            await insert_record(
+                txn,
+                "ConnectionRecord",
+                "conn-created-fallback",
+                {
+                    "createdAt": stale_time,
+                    "did": "did:example:created-fallback",
+                },
+                {},
+            )
+
+            await insert_record(
+                txn,
+                "ConnectionRecord",
+                "conn-value-tags-fallback",
+                {
+                    "_tags": {"lastSeen": stale_time},
+                    "createdAt": recent_time,
+                    "updatedAt": recent_time,
+                    "did": "did:example:value-tags-fallback",
+                },
+                {},
+            )
+
+            await insert_record(
+                txn,
+                "ConnectionRecord",
+                "conn-no-timestamp",
+                {
+                    "did": "did:example:no-timestamp",
+                },
+                {},
+            )
+            await txn.commit()
+    finally:
+        await store.close()
+
+
+async def prepare_pickup_repo(uri: str, queued_connection_ids: list[str]):
+    conn = await asyncpg.connect(uri)
+    try:
+        await conn.execute("CREATE TABLE IF NOT EXISTS queued_message (connection_id TEXT)")
+        await conn.execute("TRUNCATE queued_message")
+        for connection_id in queued_connection_ids:
+            await conn.execute(
+                "INSERT INTO queued_message (connection_id) VALUES ($1)",
+                connection_id,
+            )
+    finally:
+        await conn.close()
+
+
+async def fetch_record_names(
+    uri: str, wallet_key: str, wallet_key_derivation_method: str, category: str
+) -> set[str]:
+    store = await Store.open(
+        uri,
+        pass_key=wallet_key,
+        key_method=KEY_METHODS[wallet_key_derivation_method],
+    )
+    try:
+        async with store.transaction() as session:
+            records = await session.fetch_all(category)
+        return {record.name for record in records}
+    finally:
+        await store.close()
+
+
+class TestMediatorCleanup(WalletTypeToBeTested):
+    @pytest.mark.asyncio
+    @pytest.mark.e2e
+    async def test_mediator_cleanup_pg_seeded_records(
+        self, containers: Containers, monkeypatch
+    ):
+        postgres_port = 55432
+        postgres = containers.postgres(postgres_port, name="cleanup_postgres")
+        cleanup_container = containers.acapy_postgres(
+            "cleanup",
+            "insecure",
+            "kdf:argon2i:mod",
+            "askar",
+            3004,
+            postgres,
+        )
+        containers.wait_until_healthy(cleanup_container)
+        containers.stop(cleanup_container)
+
+        wallet_uri = (
+            f"postgres://postgres:mysecretpassword@localhost:{postgres_port}/cleanup"
+        )
+        await seed_wallet(wallet_uri, "insecure", "ARGON2I_MOD")
+        await prepare_pickup_repo(wallet_uri, ["conn-queued"])
+
+        async def run_once(self):
+            await self.cleanup()
+
+        monkeypatch.setattr(CredoMediatorCleanUp, "run", run_once)
+
+        namespace = Namespace()
+        namespace.__dict__.update(
+            {
+                "strategy": "mediator-cleanup",
+                "uri": wallet_uri,
+                "wallet_name": "cleanup",
+                "wallet_key": "insecure",
+                "wallet_key_derivation_method": "ARGON2I_MOD",
+                "inactive_days_threshold": 365,
+                "cron_job_start_time": isoformat_z(datetime.now(timezone.utc)),
+                "cron_job_interval_days": 7,
+                "pickup_repository_uri": wallet_uri,
+            }
+        )
+
+        await main(namespace)
+
+        connection_names = await fetch_record_names(
+            wallet_uri,
+            "insecure",
+            "ARGON2I_MOD",
+            "ConnectionRecord",
+        )
+        did_names = await fetch_record_names(
+            wallet_uri,
+            "insecure",
+            "ARGON2I_MOD",
+            "DidRecord",
+        )
+        mediation_names = await fetch_record_names(
+            wallet_uri,
+            "insecure",
+            "ARGON2I_MOD",
+            "MediationRecord",
+        )
+        fcm_names = await fetch_record_names(
+            wallet_uri,
+            "insecure",
+            "ARGON2I_MOD",
+            "PushNotificationsFcmRecord",
+        )
+
+        containers.stop(postgres)
+
+        assert connection_names == {
+            "conn-fresh",
+            "conn-no-timestamp",
+            "conn-queued",
+        }
+        assert "did-stale" not in did_names
+        assert "did-their-stale" not in did_names
+        assert "mediation-stale" not in mediation_names
+        assert "fcm-stale" not in fcm_names

--- a/askar_tools/tests/test_credo_mediator_clean_up.py
+++ b/askar_tools/tests/test_credo_mediator_clean_up.py
@@ -154,7 +154,7 @@ async def test_cleanup_deletes_stale_connection_and_related_records(monkeypatch)
     )
     store = FakeStore([connection_record], [FakeSession([connection_record]), txn])
     db_conn = SimpleNamespace(fetch=AsyncMock(return_value=[]))
-    conn = SimpleNamespace(uri="sqlite:///wallet.db", close=AsyncMock())
+    conn = SimpleNamespace(uri="sqlite:///wallet.db", close=AsyncMock(), connect=AsyncMock())
     pickup_repo_conn = SimpleNamespace(
         parsed_url=SimpleNamespace(
             hostname="localhost",
@@ -203,7 +203,7 @@ async def test_cleanup_skips_queued_connections(monkeypatch):
     db_conn = SimpleNamespace(
         fetch=AsyncMock(return_value=[{"connection_id": "conn-queued"}])
     )
-    conn = SimpleNamespace(uri="sqlite:///wallet.db", close=AsyncMock())
+    conn = SimpleNamespace(uri="sqlite:///wallet.db", close=AsyncMock(), connect=AsyncMock())
     pickup_repo_conn = SimpleNamespace(
         parsed_url=SimpleNamespace(
             hostname="localhost",
@@ -241,7 +241,7 @@ async def test_cleanup_keeps_connection_without_activity_timestamp(monkeypatch):
     txn = FakeTxn()
     store = FakeStore([connection_record], [FakeSession([connection_record]), txn])
     db_conn = SimpleNamespace(fetch=AsyncMock(return_value=[]))
-    conn = SimpleNamespace(uri="sqlite:///wallet.db", close=AsyncMock())
+    conn = SimpleNamespace(uri="sqlite:///wallet.db", close=AsyncMock(), connect=AsyncMock())
     pickup_repo_conn = SimpleNamespace(
         parsed_url=SimpleNamespace(
             hostname="localhost",

--- a/askar_tools/tests/test_credo_mediator_clean_up.py
+++ b/askar_tools/tests/test_credo_mediator_clean_up.py
@@ -66,6 +66,18 @@ class FakeStore:
         self.closed = True
 
 
+class StopScheduler(Exception):
+    pass
+
+
+class FakeDateTime:
+    values = iter(())
+
+    @classmethod
+    def now(cls, tz=None):
+        return next(cls.values)
+
+
 def test_get_connection_activity_time_prefers_last_seen():
     activity_time = get_connection_activity_time(
         {
@@ -258,3 +270,71 @@ async def test_cleanup_keeps_connection_without_activity_timestamp(monkeypatch):
     assert txn.committed is True
     assert store.closed is True
     conn.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_run_waits_until_start_then_sleeps_until_next_run(monkeypatch):
+    start_time = datetime(2026, 1, 1, 0, 2, tzinfo=timezone.utc)
+    FakeDateTime.values = iter(
+        [
+            datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
+            datetime(2026, 1, 1, 0, 1, tzinfo=timezone.utc),
+            start_time,
+            start_time,
+            datetime(2026, 1, 1, 0, 2, 30, tzinfo=timezone.utc),
+            datetime(2026, 1, 1, 0, 2, 30, tzinfo=timezone.utc),
+        ]
+    )
+    sleep_mock = AsyncMock()
+    cleanup_mock = AsyncMock(side_effect=[None, StopScheduler()])
+    cleanup = CredoMediatorCleanUp(
+        conn=SimpleNamespace(),
+        pickup_repo_conn=SimpleNamespace(),
+        wallet_name="wallet",
+        wallet_key="key",
+        cron_job_start_time=start_time,
+        cron_job_interval_days=1,
+    )
+    cleanup.cleanup = cleanup_mock
+
+    monkeypatch.setattr(cleanup_module, "datetime", FakeDateTime)
+    monkeypatch.setattr(cleanup_module.asyncio, "sleep", sleep_mock)
+
+    with pytest.raises(StopScheduler):
+        await cleanup.run()
+
+    assert cleanup_mock.await_count == 2
+    assert sleep_mock.await_args_list == [((60,), {}), ((60,), {}), ((86370.0,), {})]
+
+
+@pytest.mark.asyncio
+async def test_run_reruns_immediately_when_cleanup_overruns_interval(monkeypatch):
+    start_time = datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
+    FakeDateTime.values = iter(
+        [
+            start_time,
+            start_time,
+            datetime(2026, 1, 2, 0, 0, 1, tzinfo=timezone.utc),
+            datetime(2026, 1, 2, 0, 0, 1, tzinfo=timezone.utc),
+        ]
+    )
+    sleep_mock = AsyncMock()
+    cleanup_mock = AsyncMock(side_effect=[None, StopScheduler()])
+    cleanup = CredoMediatorCleanUp(
+        conn=SimpleNamespace(),
+        pickup_repo_conn=SimpleNamespace(),
+        wallet_name="wallet",
+        wallet_key="key",
+        cron_job_start_time=start_time,
+        cron_job_interval_days=1,
+    )
+    cleanup.cleanup = cleanup_mock
+
+    monkeypatch.setattr(cleanup_module, "datetime", FakeDateTime)
+    monkeypatch.setattr(cleanup_module.asyncio, "sleep", sleep_mock)
+
+    with pytest.raises(StopScheduler):
+        await cleanup.run()
+
+    assert cleanup_mock.await_count == 2
+    sleep_mock.assert_not_awaited()

--- a/askar_tools/tests/test_credo_mediator_clean_up.py
+++ b/askar_tools/tests/test_credo_mediator_clean_up.py
@@ -1,0 +1,260 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import askar_tools.credo_mediator_clean_up as cleanup_module
+from askar_tools.credo_mediator_clean_up import (CredoMediatorCleanUp,
+                                                 get_connection_activity_time)
+
+
+class FakeTransactionContext:
+    def __init__(self, transaction):
+        self.transaction = transaction
+
+    async def __aenter__(self):
+        return self.transaction
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class FakeSession:
+    def __init__(self, connection_records):
+        self.connection_records = connection_records
+
+    async def fetch_all(self, category, *args, **kwargs):
+        if category == "ConnectionRecord":
+            return self.connection_records
+        return []
+
+
+class FakeTxn:
+    def __init__(self, record_lookup=None):
+        self.record_lookup = record_lookup or {}
+        self.removed = []
+        self.committed = False
+        self.rolled_back = False
+
+    async def fetch_all(self, category, tag_filter=None, limit=None):
+        key = (category, tuple(sorted((tag_filter or {}).items())))
+        return self.record_lookup.get(key, [])
+
+    async def remove(self, category, name):
+        self.removed.append((category, name))
+
+    async def commit(self):
+        self.committed = True
+
+    async def rollback(self):
+        self.rolled_back = True
+
+
+class FakeStore:
+    def __init__(self, connection_records, transactions):
+        self.connection_records = connection_records
+        self.transactions = list(transactions)
+        self.closed = False
+
+    def transaction(self):
+        if self.transactions:
+            return FakeTransactionContext(self.transactions.pop(0))
+        return FakeTransactionContext(FakeSession(self.connection_records))
+
+    async def close(self):
+        self.closed = True
+
+
+def test_get_connection_activity_time_prefers_last_seen():
+    activity_time = get_connection_activity_time(
+        {
+            "updatedAt": "2026-03-01T00:00:00Z",
+            "createdAt": "2026-02-01T00:00:00Z",
+        },
+        {"lastSeen": "2026-03-24T20:27:09.902Z"},
+    )
+
+    assert activity_time == datetime(2026, 3, 24, 20, 27, 9, 902000, tzinfo=timezone.utc)
+
+
+def test_get_connection_activity_time_falls_back_to_updated_at():
+    activity_time = get_connection_activity_time(
+        {
+            "updatedAt": "2026-03-01T00:00:00Z",
+            "createdAt": "2026-02-01T00:00:00Z",
+        }
+    )
+
+    assert activity_time == datetime(2026, 3, 1, 0, 0, tzinfo=timezone.utc)
+
+
+def test_get_connection_activity_time_falls_back_to_created_at():
+    activity_time = get_connection_activity_time(
+        {
+            "createdAt": "2026-02-01T00:00:00",
+        }
+    )
+
+    assert activity_time == datetime(2026, 2, 1, 0, 0, tzinfo=timezone.utc)
+
+
+def test_get_connection_activity_time_falls_back_to_value_json_tags():
+    activity_time = get_connection_activity_time(
+        {
+            "_tags": {"lastSeen": "2026-03-24T20:27:09.902Z"},
+            "updatedAt": "2026-03-01T00:00:00Z",
+        }
+    )
+
+    assert activity_time == datetime(2026, 3, 24, 20, 27, 9, 902000, tzinfo=timezone.utc)
+
+
+def test_get_connection_activity_time_returns_none_without_timestamps():
+    assert get_connection_activity_time({}) is None
+
+
+@pytest.mark.asyncio
+async def test_cleanup_deletes_stale_connection_and_related_records(monkeypatch):
+    connection_record = SimpleNamespace(
+        name="conn-1",
+        value_json={
+            "theirDid": "their-did",
+            "did": "my-did",
+            "updatedAt": "2000-01-01T00:00:00Z",
+        },
+        tags={},
+    )
+    did_record = SimpleNamespace(name="did-1")
+    their_did_record = SimpleNamespace(name="did-2")
+    mediation_record = SimpleNamespace(name="mediation-1")
+    firebase_record = SimpleNamespace(name="firebase-1")
+    txn = FakeTxn(
+        {
+            ("DidRecord", (("did", "their-did"),)): [their_did_record],
+            ("DidRecord", (("did", "my-did"),)): [did_record],
+            ("MediationRecord", (("connectionId", "conn-1"),)): [mediation_record],
+            (
+                "PushNotificationsFcmRecord",
+                (("connectionId", "conn-1"),),
+            ): [firebase_record],
+        }
+    )
+    store = FakeStore([connection_record], [FakeSession([connection_record]), txn])
+    db_conn = SimpleNamespace(fetch=AsyncMock(return_value=[]))
+    conn = SimpleNamespace(uri="sqlite:///wallet.db", close=AsyncMock())
+    pickup_repo_conn = SimpleNamespace(
+        parsed_url=SimpleNamespace(
+            hostname="localhost",
+            port=5432,
+            username="user",
+            password="pass",
+            path="/db",
+        )
+    )
+
+    monkeypatch.setattr(cleanup_module.Store, "open", AsyncMock(return_value=store))
+    monkeypatch.setattr(cleanup_module.asyncpg, "connect", AsyncMock(return_value=db_conn))
+
+    cleanup = CredoMediatorCleanUp(
+        conn=conn,
+        pickup_repo_conn=pickup_repo_conn,
+        wallet_name="wallet",
+        wallet_key="key",
+        cron_job_start_time=datetime.now(timezone.utc),
+        inactive_days_threshold=365,
+    )
+
+    await cleanup.cleanup()
+
+    assert txn.removed == [
+        ("ConnectionRecord", "conn-1"),
+        ("DidRecord", "did-2"),
+        ("DidRecord", "did-1"),
+        ("MediationRecord", "mediation-1"),
+        ("PushNotificationsFcmRecord", "firebase-1"),
+    ]
+    assert txn.committed is True
+    assert store.closed is True
+    conn.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_skips_queued_connections(monkeypatch):
+    connection_record = SimpleNamespace(
+        name="conn-queued",
+        value_json={"updatedAt": "2000-01-01T00:00:00Z"},
+        tags={},
+    )
+    txn = FakeTxn()
+    store = FakeStore([connection_record], [FakeSession([connection_record]), txn])
+    db_conn = SimpleNamespace(
+        fetch=AsyncMock(return_value=[{"connection_id": "conn-queued"}])
+    )
+    conn = SimpleNamespace(uri="sqlite:///wallet.db", close=AsyncMock())
+    pickup_repo_conn = SimpleNamespace(
+        parsed_url=SimpleNamespace(
+            hostname="localhost",
+            port=5432,
+            username="user",
+            password="pass",
+            path="/db",
+        )
+    )
+
+    monkeypatch.setattr(cleanup_module.Store, "open", AsyncMock(return_value=store))
+    monkeypatch.setattr(cleanup_module.asyncpg, "connect", AsyncMock(return_value=db_conn))
+
+    cleanup = CredoMediatorCleanUp(
+        conn=conn,
+        pickup_repo_conn=pickup_repo_conn,
+        wallet_name="wallet",
+        wallet_key="key",
+        cron_job_start_time=datetime.now(timezone.utc),
+        inactive_days_threshold=365,
+    )
+
+    await cleanup.cleanup()
+
+    assert txn.removed == []
+    assert txn.committed is False
+    assert txn.rolled_back is False
+    assert store.closed is True
+    conn.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_keeps_connection_without_activity_timestamp(monkeypatch):
+    connection_record = SimpleNamespace(name="conn-1", value_json={}, tags={})
+    txn = FakeTxn()
+    store = FakeStore([connection_record], [FakeSession([connection_record]), txn])
+    db_conn = SimpleNamespace(fetch=AsyncMock(return_value=[]))
+    conn = SimpleNamespace(uri="sqlite:///wallet.db", close=AsyncMock())
+    pickup_repo_conn = SimpleNamespace(
+        parsed_url=SimpleNamespace(
+            hostname="localhost",
+            port=5432,
+            username="user",
+            password="pass",
+            path="/db",
+        )
+    )
+
+    monkeypatch.setattr(cleanup_module.Store, "open", AsyncMock(return_value=store))
+    monkeypatch.setattr(cleanup_module.asyncpg, "connect", AsyncMock(return_value=db_conn))
+
+    cleanup = CredoMediatorCleanUp(
+        conn=conn,
+        pickup_repo_conn=pickup_repo_conn,
+        wallet_name="wallet",
+        wallet_key="key",
+        cron_job_start_time=datetime.now(timezone.utc),
+        inactive_days_threshold=365,
+    )
+
+    await cleanup.cleanup()
+
+    assert txn.removed == []
+    assert txn.committed is True
+    assert store.closed is True
+    conn.close.assert_awaited_once()

--- a/askar_tools/tests/test_credo_mediator_clean_up.py
+++ b/askar_tools/tests/test_credo_mediator_clean_up.py
@@ -34,6 +34,7 @@ class FakeTxn:
     def __init__(self, record_lookup=None):
         self.record_lookup = record_lookup or {}
         self.removed = []
+        self.replaced = []
         self.committed = False
         self.rolled_back = False
 
@@ -43,6 +44,18 @@ class FakeTxn:
 
     async def remove(self, category, name):
         self.removed.append((category, name))
+
+    async def replace(self, category, name, value=None, tags=None, expiry_ms=None, value_json=None):
+        self.replaced.append(
+            {
+                "category": category,
+                "name": name,
+                "value": value,
+                "tags": tags,
+                "expiry_ms": expiry_ms,
+                "value_json": value_json,
+            }
+        )
 
     async def commit(self):
         self.committed = True
@@ -85,6 +98,18 @@ def test_get_connection_activity_time_prefers_last_seen():
             "createdAt": "2026-02-01T00:00:00Z",
         },
         {"lastSeen": "2026-03-24T20:27:09.902Z"},
+    )
+
+    assert activity_time == datetime(2026, 3, 24, 20, 27, 9, 902000, tzinfo=timezone.utc)
+
+
+def test_get_connection_activity_time_accepts_non_utc_offset():
+    activity_time = get_connection_activity_time(
+        {
+            "updatedAt": "2026-03-01T00:00:00Z",
+            "createdAt": "2026-02-01T00:00:00Z",
+        },
+        {"lastSeen": "2026-03-24T22:27:09.902+02:00"},
     )
 
     assert activity_time == datetime(2026, 3, 24, 20, 27, 9, 902000, tzinfo=timezone.utc)
@@ -254,6 +279,8 @@ async def test_cleanup_keeps_connection_without_activity_timestamp(monkeypatch):
 
     monkeypatch.setattr(cleanup_module.Store, "open", AsyncMock(return_value=store))
     monkeypatch.setattr(cleanup_module.asyncpg, "connect", AsyncMock(return_value=db_conn))
+    FakeDateTime.values = iter([datetime(2026, 4, 6, 12, 0, tzinfo=timezone.utc)])
+    monkeypatch.setattr(cleanup_module, "datetime", FakeDateTime)
 
     cleanup = CredoMediatorCleanUp(
         conn=conn,
@@ -267,6 +294,16 @@ async def test_cleanup_keeps_connection_without_activity_timestamp(monkeypatch):
     await cleanup.cleanup()
 
     assert txn.removed == []
+    assert txn.replaced == [
+        {
+            "category": "ConnectionRecord",
+            "name": "conn-1",
+            "value": None,
+            "tags": {},
+            "expiry_ms": None,
+            "value_json": {"updatedAt": "2026-04-06T12:00:00Z"},
+        }
+    ]
     assert txn.committed is True
     assert store.closed is True
     conn.close.assert_awaited_once()

--- a/askar_tools/tests/test_main.py
+++ b/askar_tools/tests/test_main.py
@@ -1,0 +1,15 @@
+from datetime import datetime, timezone
+
+from askar_tools.__main__ import parse_iso_datetime
+
+
+def test_parse_iso_datetime_accepts_z_suffix():
+    parsed = parse_iso_datetime("2026-02-24T00:00:00Z")
+
+    assert parsed == datetime(2026, 2, 24, 0, 0, tzinfo=timezone.utc)
+
+
+def test_parse_iso_datetime_defaults_naive_input_to_utc():
+    parsed = parse_iso_datetime("2026-02-24T00:00:00")
+
+    assert parsed == datetime(2026, 2, 24, 0, 0, tzinfo=timezone.utc)


### PR DESCRIPTION
This is a tool used to remove old mediated connections when the have become stale. It requires the mediator tag connections with a `lastSeen` tag. It was arguments for the length of time a connection has become stale, when to start the first cleanup and the amount of days to wait before running the cleanup again. 

If a connection record is deleted from the mediator database the connection which used it will no longer work. The recipient agent will need to create a new mediated connection.

It also checks if the connection has queued messages. In this case it will not delete the mediation records.