### PR TITLE
Repair using issuer_rev_reg records

### DIFF
--- a/askar_tools/anoncreds_repair.py
+++ b/askar_tools/anoncreds_repair.py
@@ -61,14 +61,16 @@ class Repairer:
             await store.close()
 
     async def _repair_revocation_registries(self, txn):
-        for record in await txn.fetch_all("revocation_reg_def"):
-            if await txn.fetch("revocation_reg_def_private", name=record.name):
+        for record in await txn.fetch_all("issuer_rev_reg"):
+            if await txn.fetch(
+                "revocation_reg_def_private", name=record.tags.get("revoc_reg_id")
+            ):
                 continue
             print(f"Removing broken revocation registry {record.name}")
             try:
                 issuer = await txn.fetch_all(
                     "issuer_rev_reg",
-                    tag_filter={"revoc_reg_id": record.name},
+                    tag_filter={"revoc_reg_id": record.tags.get("revoc_reg_id")},
                 )
                 for rec in issuer:
                     await self._remove_if_exists(txn, "issuer_rev_reg", rec.name)


### PR DESCRIPTION
The repair script should have been using the issuer_rev_reg records and then checking if the private information existed not revocation_reg records.

I think there must have been an old feature to delete revocation records that wasn't deleting the issuer_rev_reg records which was causing the issue with the upgrade.